### PR TITLE
Clean up HTML

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -83,11 +83,11 @@ If you are considering sharing sensitive data, bear in mind that both your work 
 	</summary>
 	<p>
 	Each organization listing in the directory will contain two key pieces of information:
+	</p>
 	<ul>
 		<li>Its landing page — the page on its website that gives information on how to contact it, along with advice on source protection specific to that organization</li>
 		<li>Its SecureDrop address — a special address that only works in Tor Browser and can be used to connect directly to its SecureDrop</li>
 	</ul>
-	</p>
 	<p>
 	Some organizations may have their 56-character long-form address listed along with their human-friendly short-form address, like <kbd>&lt;orgname&gt;.securedrop.tor.onion</kbd>. Either will work.
 	</p>
@@ -122,15 +122,12 @@ If you are planning to upload large files, you should be prepared to wait — up
         <span class="step-title"><b>Continue to protect yourself</b> &mdash; don't tell anyone about your choice to blow the whistle!</span>
     <span class="toggle-text"></span>
 	</summary>
-	<p>Protect yourself and others by keeping your whistleblowing to yourself. 
+	<p>Protect yourself and others by keeping your whistleblowing to yourself.
 	</p>
 	<p>
 If you need to seek legal counsel, you may decide to contact trusted organizations that provide aid to whistleblowers. If you do so, you should continue to use systems like Signal or SecureDrop to make contact, and you should share as little information as possible, preserving your anonymity if you can.
 	</p>
 			    </details></li>
 </ol>
-</body>
-</html>
-
 </body>
 </html>


### PR DESCRIPTION
* Remove duplicate closing body/html tags.
* Close `<p>` before `<ul>` starts, it can't cross over that.
* Trim trailing whitespace.

Spotted by looking at the HTML in Firefox's view source mode

## Test plan

* [ ] Open it in Firefox's view source mode, e.g. `view-source:http://127.0.0.1:8080/index.html`
* [ ] Verify there are no HTML nodes highlighted in red with squiggly lines.
* [ ] Visually a no-op