### PR TITLE
Add caveats from documentation source guide

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -20,7 +20,7 @@
 </header>
 <section class="intro">
     <p class="first">
-        <span class="highlight">SecureDrop  is a whistleblower submission system</span> used by news organizations worldwide, including the Washington Post, Der Spiegel, The New York Times, The Guardian, ProPublica, and others. It is designed to help whistleblowers reach out and share information safely and anonymously.
+        <span class="highlight">SecureDrop is a whistleblower submission system</span> used by news organizations worldwide, including the Washington Post, Der Spiegel, The New York Times, The Guardian, ProPublica, and others. It is designed to help whistleblowers reach out and share information safely and anonymously.
     </p>
     <p>
         As a whistleblower, you should protect yourself as much as you can. SecureDrop is intended to help you do that while you perform an essential role in civil society. Thank you, and stay safe.
@@ -129,5 +129,8 @@ If you need to seek legal counsel, you may decide to contact trusted organizatio
 	</p>
 			    </details></li>
 </ol>
+<p>
+Please note that this guide is not exhaustive, for example it does not address ethical or legal dimensions of whistleblowing. Proceed at your own risk. For additional background, also see our guide on <em>How to Share Sensitive Leaks With the Press</em> (<a href="http://fpfjxcrmw437h6z2xl3w4czl55kvkmxpapg37bbopsafdu7q454byxid.onion/digisec/blog/sharing-sensitive-leaks-press/" target="_blank" rel="nofollow">http://fpfjxcrmw437h6z2xl3w4czl55kvkmxpapg37bbopsafdu7q454byxid.onion/digisec/blog/sharing-sensitive-leaks-press</a>).
+</p>
 </body>
 </html>


### PR DESCRIPTION
This PR adds the caveats that could originally be found in the docs.securedrop.org Source Guide

This work is in relation to the ongoing docs restructuring efforts, in particular [this PR](https://github.com/freedomofpress/securedrop-docs/pull/811) and [this review comment](https://github.com/freedomofpress/securedrop-docs/pull/811#discussion_r3453569624).